### PR TITLE
Add copyright start year and  license in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,12 @@
 <footer>
-  <span id="site-copyright">&copy; {{ now.Year }}
+  <span id="site-copyright">&copy; {{ with .Site.Params.copyrightStartYear }}{{ . }}-{{ end }}{{ now.Year }}
     <a href="{{ .Site.Params.authorLink }}">{{ .Site.Params.author }}</a>
   </span>
+  {{ if .Site.Params.showLicenseInFooter -}}
+  <span id="site-license">
+    | License: <a rel="license" href="{{ .Site.Params.licenseLink }}" target="_blank">{{ .Site.Params.license }}</a>
+  </span>
+  {{ end -}}
   <span id="theme-links">
     | <a href="{{ .Site.Params.themeLink }}">{{ .Site.Params.theme }}</a> theme
     for <a href="https://gohugo.io/" target="_blank">Hugo</a>


### PR DESCRIPTION
Changes:
- Add copyright start year  in footer
- Add license in footer when `showLicenseInFooter` is `true`
