### PR TITLE
Update Pagefind path to 1.0 new default

### DIFF
--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -1,5 +1,5 @@
 {{ if .Site.Params.showSearchUI -}}
-<link href="{{ relURL "_pagefind/pagefind-ui.css" }}" rel="stylesheet" />
+<link href="{{ relURL "pagefind/pagefind-ui.css" }}" rel="stylesheet" />
 {{- end }}
 {{- $css_files := slice "css/normalize.css"  "css/base.css" "css/colors.css" "css/style.css" }}
 {{ range $css_files }}

--- a/layouts/partials/head/js.html
+++ b/layouts/partials/head/js.html
@@ -1,3 +1,3 @@
 {{ if .Site.Params.showSearchUI -}}
-<script src="{{ relURL "_pagefind/pagefind-ui.js" }}" type="text/javascript"></script>
+<script src="{{ relURL "pagefind/pagefind-ui.js" }}" type="text/javascript"></script>
 {{- end }}


### PR DESCRIPTION
Pagefind 1.0 changes the default output directory from `/_pagefind/ `to `/pagefind/`.